### PR TITLE
Avoid compilation or test warnings, remove useless parameter

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.2;
+pragma solidity ^0.4.17;
 
 contract Migrations {
   address public owner;
@@ -8,15 +8,15 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() {
+  function Migrations() public {
     owner = msg.sender;
   }
 
-  function setCompleted(uint completed) restricted {
+  function setCompleted(uint completed) public restricted {
     last_completed_migration = completed;
   }
 
-  function upgrade(address new_address) restricted {
+  function upgrade(address new_address) public restricted {
     Migrations upgraded = Migrations(new_address);
     upgraded.setCompleted(last_completed_migration);
   }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -43,7 +43,7 @@ App = {
     $(document).on('click', '.btn-adopt', App.handleAdopt);
   },
 
-  markAdopted: function(adopters, account) {
+  markAdopted: function() {
     /*
      * Replace me...
      */


### PR DESCRIPTION
## Description

When run `truffle migrate`

```
Compiling ./contracts/Migrations.sol...

Compilation warnings encountered:

/Users/lyon/Codes/packages/truffle/a/contracts/Migrations.sol:11:3: Warning: No visibility specified. Defaulting to "public".
  function Migrations() {
  ^
Spanning multiple lines.
,/Users/lyon/Codes/packages/truffle/a/contracts/Migrations.sol:15:3: Warning: No visibility specified. Defaulting to "public".
  function setCompleted(uint completed) restricted {
  ^
Spanning multiple lines.
,/Users/lyon/Codes/packages/truffle/a/contracts/Migrations.sol:19:3: Warning: No visibility specified. Defaulting to "public".
  function upgrade(address new_address) restricted {
  ^
Spanning multiple lines.

Writing artifacts to ./build/contracts

Using network 'development'.

Network up to date.
```

## Environment
* Truffle v4.1.3 (core: 4.1.3)
* Solidity v0.4.19 (solc-js)