### PR TITLE
Fix deprecation warning 

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 


### PR DESCRIPTION
Fixed `Warning: Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.` 