### PR TITLE
Remove contracts/.gitkeep. Add .gitattributes for syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ This box has all you need to get started with our [Pet Shop tutorial](http://tru
 * __How do I use this with the EthereumJS TestRPC?__
 
     It's as easy as modifying the config file! [Check out our documentation on adding network configurations](http://truffleframework.com/docs/advanced/configuration#networks). Depending on the port you're using, you'll also need to update line 16 of `src/js/app.js`.
+
+  Testing syntax highlighting.

--- a/README.md
+++ b/README.md
@@ -38,5 +38,3 @@ This box has all you need to get started with our [Pet Shop tutorial](http://tru
 * __How do I use this with the EthereumJS TestRPC?__
 
     It's as easy as modifying the config file! [Check out our documentation on adding network configurations](http://truffleframework.com/docs/advanced/configuration#networks). Depending on the port you're using, you'll also need to update line 16 of `src/js/app.js`.
-
-  Testing syntax highlighting.


### PR DESCRIPTION
* Remove .gitkeep as it's no longer needed. When it was added that directory was empty so it allowed the directory to be committed to git. It's no longer needed as that directory is no longer empty.
* Add .gitattributes so that Github shows syntax highlighting for Solidity. I learned about this from [Open Zeppelin's repo](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/.gitattributes)